### PR TITLE
Crear api control medicamentos php

### DIFF
--- a/meds-api/README.md
+++ b/meds-api/README.md
@@ -1,0 +1,63 @@
+# API de Control de Medicamentos (PHP + SQLite)
+
+API REST mínima en PHP sin dependencias externas. Usa SQLite como almacenamiento embebido y el servidor embebido de PHP.
+
+## Ejecutar
+
+1. Requisitos: PHP 8.1+
+2. Arrancar el servidor:
+
+```bash
+php -S 0.0.0.0:8000 -t public /workspace/meds-api/public/index.php
+```
+
+La base de datos se crea automáticamente en `data/database.sqlite` al primer arranque.
+
+## Endpoints
+
+- `GET /medications` — Lista medicamentos
+- `POST /medications` — Crea medicamento
+- `GET /medications/{id}` — Detalle
+- `PUT /medications/{id}` — Actualiza
+- `DELETE /medications/{id}` — Elimina
+- `POST /medications/{id}/adjust_stock` — Ajusta stock con `{ "delta": +/-N }`
+
+Cabeceras: `Content-Type: application/json`
+
+## Ejemplos
+
+Crear:
+
+```bash
+curl -X POST http://localhost:8000/medications \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Paracetamol","dosage":"500 mg","stock":100,"notes":"Tomar con agua"}'
+```
+
+Listar:
+
+```bash
+curl http://localhost:8000/medications
+```
+
+Actualizar:
+
+```bash
+curl -X PUT http://localhost:8000/medications/1 \
+  -H 'Content-Type: application/json' \
+  -d '{"stock":120}'
+```
+
+Ajustar stock (-5):
+
+```bash
+curl -X POST http://localhost:8000/medications/1/adjust_stock \
+  -H 'Content-Type: application/json' \
+  -d '{"delta":-5}'
+```
+
+Eliminar:
+
+```bash
+curl -X DELETE http://localhost:8000/medications/1
+```

--- a/meds-api/bootstrap.php
+++ b/meds-api/bootstrap.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+error_reporting(E_ALL);
+ini_set('display_errors', '1');
+
+// Base path
+const BASE_PATH = __DIR__;
+
+// Autoload simple (manual requires)
+require_once BASE_PATH . '/src/Database.php';
+require_once BASE_PATH . '/src/Router.php';
+require_once BASE_PATH . '/src/MedicationController.php';
+
+// Basic CORS for local development and simple integrations
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+header('Content-Type: application/json; charset=utf-8');
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+	echo json_encode(['status' => 'ok']);
+	exit;
+}
+
+/**
+ * Read JSON body as associative array.
+ */
+function readJsonBody(): array {
+	$raw = file_get_contents('php://input');
+	if ($raw === false || $raw === '') {
+		return [];
+	}
+	$decoded = json_decode($raw, true);
+	return is_array($decoded) ? $decoded : [];
+}
+
+/**
+ * Send a JSON response with HTTP status code.
+ */
+function sendJson(int $statusCode, array $payload): void {
+	http_response_code($statusCode);
+	echo json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+}
+
+// Ensure database and schema exist
+\App\Database::initialize();

--- a/meds-api/public/index.php
+++ b/meds-api/public/index.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/bootstrap.php';
+
+use App\Router;
+use App\MedicationController;
+
+$router = new Router();
+$controller = new MedicationController();
+
+// Routes
+$router->addRoute('GET', '/medications', [$controller, 'listMedications']);
+$router->addRoute('POST', '/medications', [$controller, 'createMedication']);
+$router->addRoute('GET', '/medications/(\d+)', [$controller, 'getMedication']);
+$router->addRoute('PUT', '/medications/(\d+)', [$controller, 'updateMedication']);
+$router->addRoute('DELETE', '/medications/(\d+)', [$controller, 'deleteMedication']);
+$router->addRoute('POST', '/medications/(\d+)/adjust_stock', [$controller, 'adjustStock']);
+
+// Dispatch
+$router->dispatch($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI']);

--- a/meds-api/src/Database.php
+++ b/meds-api/src/Database.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use PDO;
+use PDOException;
+
+class Database {
+	private static ?PDO $connection = null;
+
+	public static function getConnection(): PDO {
+		if (self::$connection !== null) {
+			return self::$connection;
+		}
+
+		$databaseDirectory = BASE_PATH . '/data';
+		$databasePath = $databaseDirectory . '/database.sqlite';
+
+		if (!is_dir($databaseDirectory)) {
+			mkdir($databaseDirectory, 0777, true);
+		}
+
+		$dsn = 'sqlite:' . $databasePath;
+		$options = [
+			PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+			PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+		];
+
+		try {
+			self::$connection = new PDO($dsn, null, null, $options);
+		} catch (PDOException $e) {
+			http_response_code(500);
+			echo json_encode(['error' => 'Database connection failed', 'details' => $e->getMessage()]);
+			exit;
+		}
+
+		return self::$connection;
+	}
+
+	public static function initialize(): void {
+		$conn = self::getConnection();
+		// Create tables if they do not exist
+		$conn->exec(
+			'CREATE TABLE IF NOT EXISTS medications (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				name TEXT NOT NULL,
+				dosage TEXT,
+				stock INTEGER NOT NULL DEFAULT 0,
+				notes TEXT,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			)'
+		);
+
+		// Simple index for searches by name
+		$conn->exec('CREATE INDEX IF NOT EXISTS idx_medications_name ON medications(name)');
+	}
+}

--- a/meds-api/src/MedicationController.php
+++ b/meds-api/src/MedicationController.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use PDO;
+use PDOException;
+
+class MedicationController {
+	private PDO $db;
+
+	public function __construct() {
+		$this->db = Database::getConnection();
+	}
+
+	public function listMedications(): void {
+		$query = 'SELECT id, name, dosage, stock, notes, created_at, updated_at FROM medications ORDER BY name ASC';
+		$rows = $this->db->query($query)->fetchAll();
+		sendJson(200, ['data' => $rows]);
+	}
+
+	public function getMedication(string $id): void {
+		$stmt = $this->db->prepare('SELECT id, name, dosage, stock, notes, created_at, updated_at FROM medications WHERE id = :id');
+		$stmt->execute([':id' => (int)$id]);
+		$med = $stmt->fetch();
+		if (!$med) {
+			sendJson(404, ['error' => 'Medication not found']);
+			return;
+		}
+		sendJson(200, ['data' => $med]);
+	}
+
+	public function createMedication(): void {
+		$body = readJsonBody();
+		$name = trim((string)($body['name'] ?? ''));
+		$dosage = isset($body['dosage']) ? trim((string)$body['dosage']) : null;
+		$stock = isset($body['stock']) ? (int)$body['stock'] : 0;
+		$notes = isset($body['notes']) ? trim((string)$body['notes']) : null;
+
+		if ($name === '') {
+			sendJson(422, ['error' => 'Field "name" is required']);
+			return;
+		}
+
+		$now = (new \DateTimeImmutable('now'))->format(DATE_ATOM);
+		$stmt = $this->db->prepare('INSERT INTO medications(name, dosage, stock, notes, created_at, updated_at) VALUES(:name, :dosage, :stock, :notes, :created_at, :updated_at)');
+		try {
+			$stmt->execute([
+				':name' => $name,
+				':dosage' => $dosage,
+				':stock' => $stock,
+				':notes' => $notes,
+				':created_at' => $now,
+				':updated_at' => $now,
+			]);
+			$id = (int)$this->db->lastInsertId();
+			$this->getMedication((string)$id);
+		} catch (PDOException $e) {
+			sendJson(500, ['error' => 'Failed to create medication', 'details' => $e->getMessage()]);
+		}
+	}
+
+	public function updateMedication(string $id): void {
+		$body = readJsonBody();
+		$fields = [];
+		$params = [':id' => (int)$id, ':updated_at' => (new \DateTimeImmutable('now'))->format(DATE_ATOM)];
+
+		if (array_key_exists('name', $body)) {
+			$fields[] = 'name = :name';
+			$params[':name'] = trim((string)$body['name']);
+		}
+		if (array_key_exists('dosage', $body)) {
+			$fields[] = 'dosage = :dosage';
+			$params[':dosage'] = $body['dosage'] !== null ? trim((string)$body['dosage']) : null;
+		}
+		if (array_key_exists('stock', $body)) {
+			$fields[] = 'stock = :stock';
+			$params[':stock'] = (int)$body['stock'];
+		}
+		if (array_key_exists('notes', $body)) {
+			$fields[] = 'notes = :notes';
+			$params[':notes'] = $body['notes'] !== null ? trim((string)$body['notes']) : null;
+		}
+
+		if (empty($fields)) {
+			sendJson(400, ['error' => 'No fields to update']);
+			return;
+		}
+
+		$setClause = implode(', ', $fields) . ', updated_at = :updated_at';
+		$stmt = $this->db->prepare("UPDATE medications SET $setClause WHERE id = :id");
+
+		try {
+			$stmt->execute($params);
+			if ($stmt->rowCount() === 0) {
+				sendJson(404, ['error' => 'Medication not found']);
+				return;
+			}
+			$this->getMedication($id);
+		} catch (PDOException $e) {
+			sendJson(500, ['error' => 'Failed to update medication', 'details' => $e->getMessage()]);
+		}
+	}
+
+	public function deleteMedication(string $id): void {
+		$stmt = $this->db->prepare('DELETE FROM medications WHERE id = :id');
+		try {
+			$stmt->execute([':id' => (int)$id]);
+			if ($stmt->rowCount() === 0) {
+				sendJson(404, ['error' => 'Medication not found']);
+				return;
+			}
+			sendJson(200, ['message' => 'Medication deleted']);
+		} catch (PDOException $e) {
+			sendJson(500, ['error' => 'Failed to delete medication', 'details' => $e->getMessage()]);
+		}
+	}
+
+	public function adjustStock(string $id): void {
+		$body = readJsonBody();
+		$delta = (int)($body['delta'] ?? 0);
+		if ($delta === 0) {
+			sendJson(422, ['error' => 'Field "delta" must be non-zero']);
+			return;
+		}
+
+		try {
+			$this->db->beginTransaction();
+			$row = $this->db->prepare('SELECT stock FROM medications WHERE id = :id');
+			$row->execute([':id' => (int)$id]);
+			$current = $row->fetchColumn();
+			if ($current === false) {
+				$this->db->rollBack();
+				sendJson(404, ['error' => 'Medication not found']);
+				return;
+			}
+			$newStock = (int)$current + $delta;
+			if ($newStock < 0) {
+				$this->db->rollBack();
+				sendJson(422, ['error' => 'Stock cannot be negative']);
+				return;
+			}
+			$upd = $this->db->prepare('UPDATE medications SET stock = :stock, updated_at = :updated_at WHERE id = :id');
+			$upd->execute([
+				':stock' => $newStock,
+				':updated_at' => (new \DateTimeImmutable('now'))->format(DATE_ATOM),
+				':id' => (int)$id,
+			]);
+			$this->db->commit();
+			$this->getMedication($id);
+		} catch (PDOException $e) {
+			if ($this->db->inTransaction()) {
+				$this->db->rollBack();
+			}
+			sendJson(500, ['error' => 'Failed to adjust stock', 'details' => $e->getMessage()]);
+		}
+	}
+}

--- a/meds-api/src/Router.php
+++ b/meds-api/src/Router.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+class Router {
+	/** @var array<int, array{method:string, pattern:string, handler:callable}> */
+	private array $routes = [];
+
+	public function addRoute(string $method, string $pattern, callable $handler): void {
+		$this->routes[] = [
+			'method' => strtoupper($method),
+			'pattern' => '#^' . $pattern . '$#',
+			'handler' => $handler,
+		];
+	}
+
+	public function dispatch(string $method, string $path): void {
+		$method = strtoupper($method);
+		$path = parse_url($path, PHP_URL_PATH) ?? '/';
+
+		foreach ($this->routes as $route) {
+			if ($route['method'] !== $method) {
+				continue;
+			}
+			if (preg_match($route['pattern'], $path, $matches)) {
+				array_shift($matches); // Drop the full match
+				$handler = $route['handler'];
+				$handler(...$matches);
+				return;
+			}
+		}
+
+		http_response_code(404);
+		echo json_encode(['error' => 'Route not found']);
+	}
+}


### PR DESCRIPTION
Adds a minimal PHP REST API for medication control with CRUD operations and SQLite.

---
<a href="https://cursor.com/background-agent?bcId=bc-d455b0d9-c8ad-40f1-ab0d-80528c6384ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d455b0d9-c8ad-40f1-ab0d-80528c6384ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

